### PR TITLE
ページ中の画像の最大幅を制限

### DIFF
--- a/src/client/styl/index.styl
+++ b/src/client/styl/index.styl
@@ -139,6 +139,8 @@ div.editor
     color: #fff
     text-decoration: none
     padding: 0.1em 0.2em 0.1em 0.2em
+  img
+    max-width: 95%
   img.usericon
     margin-left: 0.2em
     width: 1.2em


### PR DESCRIPTION
ページ幅を超える画像を張り付けると以下のようになってしまうのを

![](https://i.gyazo.com/b1cd6bb69ccbd48148b87fffb7a11aa4.png)

こうなるように修正しました。

![](https://i.gyazo.com/bf0586ec1cff1b0415852775cb77efe6.png)

マージ検討お願いします。
